### PR TITLE
Add CI workflow to check for missed updates to readme ToC

### DIFF
--- a/.github/workflows/check-toc.yml
+++ b/.github/workflows/check-toc.yml
@@ -1,0 +1,46 @@
+name: Check ToC
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-toc.ya?ml"
+      - "README.md"
+  pull_request:
+    paths:
+      - ".github/workflows/check-toc.ya?ml"
+      - "README.md"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check:
+    name: ${{ matrix.file.name }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        file:
+          - name: README.md
+            # Max ToC depth, for use with the markdown-toc --maxdepth flag.
+            maxdepth: 3
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install markdown-toc
+        run: sudo npm install --global markdown-toc
+
+      - name: Rebuild ToC
+        run: |
+          markdown-toc \
+            --bullets=- \
+            --maxdepth=${{ matrix.file.maxdepth }} \
+            -i \
+            "${{ github.workspace }}/${{ matrix.file.name }}"
+
+      - name: Check ToC
+        run: git diff --color --exit-code

--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ projects:
   - [`path`](#path)
   - [`version`](#version)
   - [`compliance`](#compliance)
-  - [`format`](#format)
   - [`library-manager`](#library-manager)
   - [`project-type`](#project-type)
   - [`recursive`](#recursive)
   - [`report-file`](#report-file)
+  - [`verbose`](#verbose)
   - [`token`](#token)
 - [Usage](#usage)
+- [Contributing](#contributing)
 
 <!-- tocstop -->
 


### PR DESCRIPTION
On every push or pull request that affects the repository's README.md, use [markdown-toc](https://github.com/jonschlinkert/markdown-toc) to check whether the table of contents matches the content.