### PR TITLE
Bump `actions/setup-node` to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Node.js 10.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 10.x
 


### PR DESCRIPTION
[The `actions/setup-node` GitHub Actions action](https://github.com/actions/setup-node) is used in the "test" workflow to setup a specific version range of Node.js for use in the GitHub Actions runner.

The 2.x.x major version series of the action is now well into production status and the 1.x.x series is no longer under active development.

The use of the `v2` major version ref will cause the workflow to use a stable version of the action, while also benefiting from ongoing development to the action up until such time as a new major release of an action is made. At that time we would need to evaluate whether any changes to the workflow are required by the breaking change that triggered the major release before manually updating the major ref (e.g., uses: `actions/setup-node@v3`).

---

Supersedes https://github.com/arduino/arduino-lint-action/pull/22