### PR TITLE
Remove unnecessary build steps from integration test workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,12 +36,6 @@ jobs:
       - name: Checkout local repository
         uses: actions/checkout@v2
 
-      - name: Build action
-        run: |
-          npm install
-          npm run build
-          npm run pack
-
       # The contents of the test data path are structured so that the step will fail if arduino-lint is not run with the configuration according to these inputs.
       - name: Run action
         uses: ./
@@ -64,12 +58,6 @@ jobs:
     steps:
       - name: Checkout local repository
         uses: actions/checkout@v2
-
-      - name: Build action
-        run: |
-          npm install
-          npm run build
-          npm run pack
 
       # The contents of the test data path are structured so that the step will fail if arduino-lint is run with the default configuration.
       - name: Run action


### PR DESCRIPTION
Now that the development policy is to continuously package the project (https://github.com/arduino/arduino-lint-action/commit/f365dbdebe6a40389b78fff176dacaad3ede742f), and this policy is enforced by [a CI workflow](https://github.com/arduino/arduino-lint-action/blob/main/.github/workflows/check-packaging-ncc-typescript-npm.yml),
The action will always be pre-built, so building it again during the integration test workflow runs is pointless.

One of the build steps was removed from the workflow at the time the development policy was changed (https://github.com/arduino/arduino-lint-action/commit/01b5627902760a0d15893d4126e331137c258169), but the build steps in the other two jobs were missed at that time.