### PR TITLE
Remove inappropriate element from paths filters of "Check Packaging" workflow

### DIFF
--- a/.github/workflows/check-packaging-ncc-typescript-npm.yml
+++ b/.github/workflows/check-packaging-ncc-typescript-npm.yml
@@ -11,7 +11,6 @@ on:
       - "lerna.json"
       - "package.json"
       - "package-lock.json"
-      - "Taskfile.ya?ml"
       - "tsconfig.json"
       - "**.[jt]sx?"
   pull_request:
@@ -20,7 +19,6 @@ on:
       - "lerna.json"
       - "package.json"
       - "package-lock.json"
-      - "Taskfile.ya?ml"
       - "tsconfig.json"
       - "**.[jt]sx?"
   workflow_dispatch:


### PR DESCRIPTION
The [`on.*.paths` keys of GitHub workflows](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onpushpull_requestpaths) can be used to avoid unnecessary or unwanted workflow runs. This is done by
defining specific paths containing files relevant to the workflow's purpose. The workflow will only run when the trigger
event modifies a file matching the paths.

The "Check Packaging" workflow was copied from another project that uses [the Task task runner tool](https://taskfile.dev/#/) In that project, it is appropriate for the workflow to be triggered on any change to the Task configuration file, and so it was added to the `paths` filter. This project uses npm instead of Task, and does not contain a taskfile, so the presence of that path in the filters is inappropriate and only adds unnecessary complexity to the workflow.