### PR TITLE
Install referenced schema in "Check npm" workflow

### DIFF
--- a/.github/workflows/check-npm.yml
+++ b/.github/workflows/check-npm.yml
@@ -43,6 +43,16 @@ jobs:
           file-name: package-json-schema.json
 
       # This schema is referenced by the package.json schema, so must also be accessible.
+      - name: Download JSON schema for ava.json
+        id: download-ava-schema
+        uses: carlosperate/download-file-action@v1
+        with:
+          # See: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/ava.json
+          file-url: https://json.schemastore.org/ava.json
+          location: ${{ runner.temp }}/json-schema
+          file-name: ava.json
+
+      # This schema is referenced by the package.json schema, so must also be accessible.
       - name: Download JSON schema for eslintrc.json
         id: download-eslintrc-schema
         uses: carlosperate/download-file-action@v1
@@ -71,6 +81,7 @@ jobs:
           # See: https://github.com/ajv-validator/ajv-cli#readme
           ajv validate \
             -s "${{ steps.download-schema.outputs.file-path }}" \
+            -r "${{ steps.download-ava-schema.outputs.file-path }}" \
             -r "${{ steps.download-eslintrc-schema.outputs.file-path }}" \
             -r "${{ steps.download-prettierrc-schema.outputs.file-path }}" \
             -d "./**/package.json"


### PR DESCRIPTION
The "Check npm" GitHub Actions workflow validates the repository's `package.json` npm manifest file against its JSON schema to catch any problems with its data format.

In order to avoid duplication of content, JSON schemas may reference other schemas via the `$ref` keyword. The `package.json` schema was recently updated to share resources with the `ava.json` schema, which caused the validation to start failing:

```text
schema /home/runner/work/_temp/json-schema/package-json-schema.json is invalid
error: can't resolve reference https://json.schemastore.org/ava.json from id #
```

The solution is to configure the workflow to download that schema as well and also to provide its path to the avj-cli validator via an `-r` flag.