### PR TITLE
Install referenced schema in "Check npm" workflow

### DIFF
--- a/.github/workflows/check-npm.yml
+++ b/.github/workflows/check-npm.yml
@@ -63,6 +63,16 @@ jobs:
           file-name: eslintrc-schema.json
 
       # This schema is referenced by the package.json schema, so must also be accessible.
+      - name: Download JSON schema for jscpd configuration file
+        id: download-jscpd-schema
+        uses: carlosperate/download-file-action@v1
+        with:
+          # See: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/jscpd.json
+          file-url: https://json.schemastore.org/jscpd.json
+          location: ${{ runner.temp }}/json-schema
+          file-name: jscpd-schema.json
+
+      # This schema is referenced by the package.json schema, so must also be accessible.
       - name: Download JSON schema for Prettier configuration file
         id: download-prettierrc-schema
         uses: carlosperate/download-file-action@v1
@@ -103,6 +113,7 @@ jobs:
             -s "${{ steps.download-schema.outputs.file-path }}" \
             -r "${{ steps.download-ava-schema.outputs.file-path }}" \
             -r "${{ steps.download-eslintrc-schema.outputs.file-path }}" \
+            -r "${{ steps.download-jscpd-schema.outputs.file-path }}" \
             -r "${{ steps.download-prettierrc-schema.outputs.file-path }}" \
             -r "${{ steps.download-semantic-release-schema.outputs.file-path }}" \
             -r "${{ steps.download-stylelintrc-schema.outputs.file-path }}" \


### PR DESCRIPTION
The "Check npm" GitHub Actions workflow validates the repository's `package.json` npm manifest file against its JSON schema to catch any problems with its data format.

In order to avoid duplication of content, JSON schemas may reference other schemas via the `$ref` keyword. The `package.json` schema was recently updated to share resources with the jscpd configuration schema, which caused the validation to start failing:

schema /home/runner/work/_temp/json-schema/package-json-schema.json is invalid
error: can't resolve reference https://json.schemastore.org/jscpd.json from id #

The solution is to configure the workflow to download that schema as well and also to provide its path to the avj-cli validator via an `-r` flag.