### PR TITLE
Specify Node.js 16.x runtime for action execution in runner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ inputs:
     required: false
     default: ${{ github.token }}
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "check-square"


### PR DESCRIPTION
The Node.js version for use when executing the action in the GitHub Actions runner is configured via the [`runs.using`](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing) field of the [`action.yml` metadata file](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions).

Previously, the action was configured to use **Node.js** 12.x. This was actually the result of an oversight, as **Node.js** 16.x has been used for the development and validation of the action since 2022-01-11 (https://github.com/arduino/arduino-lint-action/pull/42). It will be important to use the same version on the runner as the action is validated for by the project infrastructure in order to ensure the expected behavior.

In addition, [GitHub has deprecated the use of Node.js 12.x runtime](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). A warning about this was shown in the workflow run summary page of all workflows using this action (https://github.com/arduino/arduino-lint-action/issues/182). That warning will be resolved, and the eventual complete breakage of those workflows avoided, by this change.

---

Fixes https://github.com/arduino/arduino-lint-action/issues/182