### PR TITLE
Use `engines.node` as source of version data for "actions/setup-node" action

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,7 +9,9 @@
 Follow the installation instructions here:<br />
 https://nodejs.dev/download
 
-Node.js 20.x is used for development of this project. [nvm](https://github.com/nvm-sh/nvm) is recommended to easily switch between Node.js versions.
+The **Node.js** version in use is defined in the `engines.node` field of [`package.json`](../package.json).
+
+[nvm](https://github.com/nvm-sh/nvm) is recommended to easily switch between Node.js versions.
 
 ### 2. Install dependencies
 

--- a/.github/workflows/check-npm.yml
+++ b/.github/workflows/check-npm.yml
@@ -1,9 +1,5 @@
 name: Check npm
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 20.x
-
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   push:
@@ -162,7 +158,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/check-packaging-ncc-typescript-npm.yml
+++ b/.github/workflows/check-packaging-ncc-typescript-npm.yml
@@ -1,9 +1,5 @@
 name: Check Packaging
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 20.x
-
 on:
   push:
     paths:
@@ -35,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,5 @@
 name: Test Action
 
-env:
-  # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 20.x
-
 on:
   push:
   pull_request:
@@ -31,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: package.json
 
       - name: npm install
         run: npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,9 @@
         "prettier": "^3.3.3",
         "ts-jest": "^28.0.8",
         "typescript": "^5.6.2"
+      },
+      "engines": {
+        "node": "20.x"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "prettier": "^3.3.3",
     "ts-jest": "^28.0.8",
     "typescript": "^5.6.2"
+  },
+  "engines": {
+    "node": "20.x"
   }
 }


### PR DESCRIPTION
The [**actions/setup-node**](https://github.com/actions/setup-node) GitHub Actions action is used to set up **Node.js** in the GitHub Actions runner machine.

The action supports obtaining the Node.js version to set up from the `engines.node` property of the package.json file:

https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file

This allows us to define the standardized version of **Node.js** for use by project infrastructure and contributors in a single place rather than having to maintain multiple instances of that data.