### PR TITLE
Bump `@types/node` to 20.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@actions/io": "^1.1.3",
         "@types/jest": "^28.1.8",
-        "@types/node": "^16.18.112",
+        "@types/node": "^20.16.10",
         "@types/semver": "^7.5.8",
         "@vercel/ncc": "^0.38.2",
         "jest": "^28.1.3",
@@ -1424,10 +1424,14 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.18.112",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.112.tgz",
-      "integrity": "sha512-EKrbKUGJROm17+dY/gMi31aJlGLJ75e1IkTojt9n6u+hnaTBDs+M1bIdOawpk2m6YUAXq/R2W0SxCng1tndHCg==",
-      "dev": true
+      "version": "20.16.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.10.tgz",
+      "integrity": "sha512-vQUKgWTjEIRFCvK6CyriPH3MZYiYlNy0fKiEYHWbcoWLEgs4opurGGKlebrTLqdSMIbXImH6XExNiIyNUv3WpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.1.5",
@@ -5664,6 +5668,13 @@
         "node": ">=14.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -6922,10 +6933,13 @@
       }
     },
     "@types/node": {
-      "version": "16.18.112",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.112.tgz",
-      "integrity": "sha512-EKrbKUGJROm17+dY/gMi31aJlGLJ75e1IkTojt9n6u+hnaTBDs+M1bIdOawpk2m6YUAXq/R2W0SxCng1tndHCg==",
-      "dev": true
+      "version": "20.16.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.10.tgz",
+      "integrity": "sha512-vQUKgWTjEIRFCvK6CyriPH3MZYiYlNy0fKiEYHWbcoWLEgs4opurGGKlebrTLqdSMIbXImH6XExNiIyNUv3WpA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.19.2"
+      }
     },
     "@types/prettier": {
       "version": "2.1.5",
@@ -10081,6 +10095,12 @@
       "requires": {
         "@fastify/busboy": "^2.0.0"
       }
+    },
+    "undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "uuid": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@actions/io": "^1.1.3",
     "@types/jest": "^28.1.8",
-    "@types/node": "^16.18.112",
+    "@types/node": "^20.16.10",
     "@types/semver": "^7.5.8",
     "@vercel/ncc": "^0.38.2",
     "jest": "^28.1.3",


### PR DESCRIPTION
The major version number of the action's `@types/node` dependency should match the version of Node.js in use.

Node.js was bumped to 20.x (https://github.com/arduino/arduino-lint-action/pull/350), so `@types/node` must also be bumped.