### PR TITLE
Configure npm to enforce standard project Node.js version

### DIFF
--- a/.github/workflows/check-npm.yml
+++ b/.github/workflows/check-npm.yml
@@ -5,11 +5,13 @@ on:
   push:
     paths:
       - ".github/workflows/check-npm.ya?ml"
+      - "**/.npmrc"
       - "**/package.json"
       - "**/package-lock.json"
   pull_request:
     paths:
       - ".github/workflows/check-npm.ya?ml"
+      - "**/.npmrc"
       - "**/package.json"
       - "**/package-lock.json"
   schedule:

--- a/.github/workflows/check-packaging-ncc-typescript-npm.yml
+++ b/.github/workflows/check-packaging-ncc-typescript-npm.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - ".github/workflows/check-packaging-ncc-typescript-npm.yml"
+      - ".npmrc"
       - "lerna.json"
       - "package.json"
       - "package-lock.json"
@@ -12,6 +13,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/check-packaging-ncc-typescript-npm.yml"
+      - ".npmrc"
       - "lerna.json"
       - "package.json"
       - "package-lock.json"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# See: https://docs.npmjs.com/cli/configuring-npm/npmrc
+
+engine-strict = true


### PR DESCRIPTION
This will produce an error if a contributor attempts to run an `npm` command in the project using an unsupported version of **Node.js**.