### PR TITLE
Update snippets in readme to use v2 ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: arduino/arduino-lint-action@v1
+      - uses: arduino/arduino-lint-action@v2
 ```
 
 A more complex workflow which uses [inputs](#inputs) to configure the action for Library Manager ["update" mode](#library-manager) and strict compliance:
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: arduino/arduino-lint-action@v1
+      - uses: arduino/arduino-lint-action@v2
         with:
           library-manager: update
           compliance: strict


### PR DESCRIPTION
A 2.0.0 release of the action has been made. To accompany it, a `v2` major version ref has been created. For this reason, in order to use the latest release of the action, the `v2` major version ref must now be used in workflows.

The workflow snippets in the readme are hereby updated to demonstrate the use of this major version ref.