### PR TITLE
Correct "setup-licensed" action ref in dependencies license check workflow

### DIFF
--- a/.github/workflows/check-npm-dependencies-task.yml
+++ b/.github/workflows/check-npm-dependencies-task.yml
@@ -77,7 +77,7 @@ jobs:
           ruby-version: ruby # Install latest version
 
       - name: Install licensed
-        uses: jonabc/setup-licensed@v1
+        uses: github/setup-licensed@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/check-npm-dependencies-task.yml
+++ b/.github/workflows/check-npm-dependencies-task.yml
@@ -77,7 +77,7 @@ jobs:
           ruby-version: ruby # Install latest version
 
       - name: Install licensed
-        uses: github/setup-licensed@v1
+        uses: github/setup-licensed@v1.3.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x


### PR DESCRIPTION
This GitHub Actions action is used by the "Check Go Dependencies" workflow to install the "Licensed" tool in the runner workspace. At the time the workflow was developed, the action was owned by GitHub user `jonabc`, and so the action was referenced as `jonabc/setup-licensed` in the workflow.

Since that time, the action was transferred to the `github` GitHub organization:

https://github.com/github/setup-licensed

Making things more confusing is the fact that there is now [a development fork](https://github.com/jonabc/setup-licensed) of the `github/setup-licensed` repository under GitHub user `jonabc`'s account, meaning that the redirect GitHub provides from the old to the new repository after a transfer does not exist for this action. This resulted in the workflow referencing an outdated copy of the action not intended for production use.

The workflow is hereby updated to use the latest version of the canonical "github/setup-licensed" action.