### PR TITLE
Remove trailing space from dependency license metadata

### DIFF
--- a/.licenses/npm/@fastify/busboy.dep.yml
+++ b/.licenses/npm/@fastify/busboy.dep.yml
@@ -3,7 +3,7 @@ name: "@fastify/busboy"
 version: 2.0.0
 type: npm
 summary: A streaming parser for HTML form data for node.js
-homepage: 
+homepage:
 license: mit
 licenses:
 - sources: LICENSE

--- a/.licenses/npm/semver-6.3.0.dep.yml
+++ b/.licenses/npm/semver-6.3.0.dep.yml
@@ -3,7 +3,7 @@ name: semver
 version: 6.3.0
 type: npm
 summary: The semantic version parser used by npm.
-homepage: 
+homepage:
 license: isc
 licenses:
 - sources: LICENSE


### PR DESCRIPTION
The dependency license metadata is generated by the [**Licensed**](https://github.com/github/licensed) tool. Previous versions of this tool added a trailing space on the `summary` key. Although trailing whitespace in human produced content is not permitted, machine generated content is used as-is, and so these trailing spaces were left in the metadata files.

It seems that the defect in the **Licensed** tool that caused the trailing space was fixed in a recent version because it is now absent in the metadata files produced by the tool. The metadata files are hereby updated to use the format of the version of the **Licensed** tool currently in use.