### PR TITLE
Fix npm validate nodemon schema

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -170,6 +170,10 @@ tasks:
       JSCPD_SCHEMA_URL: https://json.schemastore.org/jscpd.json
       JSCPD_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="jscpd-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/nodemon.json
+      NODEMON_SCHEMA_URL: https://json.schemastore.org/nodemon.json
+      NODEMON_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="nodemon-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/npm-badges.json
       NPM_BADGES_SCHEMA_URL: https://json.schemastore.org/npm-badges.json
       NPM_BADGES_SCHEMA_PATH:
@@ -182,18 +186,14 @@ tasks:
       PRETTIERRC_SCHEMA_URL: https://json.schemastore.org/prettierrc.json
       PRETTIERRC_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="prettierrc-schema-XXXXXXXXXX.json"
-      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/semantic-release.json
-      SEMANTIC_RELEASE_SCHEMA_URL: https://json.schemastore.org/semantic-release.json
-      SEMANTIC_RELEASE_SCHEMA_PATH:
-        sh: task utility:mktemp-file TEMPLATE="semantic-release-schema-XXXXXXXXXX.json"
-      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/nodemon.json
-      NODEMON_SCHEMA_URL: https://json.schemastore.org/nodemon.json
-      NODEMON_SCHEMA_PATH:
-        sh: task utility:mktemp-file TEMPLATE="nodemon-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/quikrun.json
       QUIKRUN_SCHEMA_URL: https://json.schemastore.org/quikrun.json
       QUIKRUN_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="quikrun-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/semantic-release.json
+      SEMANTIC_RELEASE_SCHEMA_URL: https://json.schemastore.org/semantic-release.json
+      SEMANTIC_RELEASE_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="semantic-release-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/stylelintrc.json
       STYLELINTRC_SCHEMA_URL: https://json.schemastore.org/stylelintrc.json
       STYLELINTRC_SCHEMA_PATH:
@@ -206,12 +206,12 @@ tasks:
       - wget --quiet --output-document="{{.BASE_SCHEMA_PATH}}" {{.BASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.ESLINTRC_SCHEMA_PATH}}" {{.ESLINTRC_SCHEMA_URL}}
       - wget --quiet --output-document="{{.JSCPD_SCHEMA_PATH}}" {{.JSCPD_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.NODEMON_SCHEMA_PATH}}" {{.NODEMON_SCHEMA_URL}}
       - wget --quiet --output-document="{{.NPM_BADGES_SCHEMA_PATH}}" {{.NPM_BADGES_SCHEMA_URL}}
       - wget --quiet --output-document="{{.PARTIAL_ESLINT_PLUGINS_PATH}}" {{.PARTIAL_ESLINT_PLUGINS_SCHEMA_URL}}
       - wget --quiet --output-document="{{.PRETTIERRC_SCHEMA_PATH}}" {{.PRETTIERRC_SCHEMA_URL}}
-      - wget --quiet --output-document="{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" {{.SEMANTIC_RELEASE_SCHEMA_URL}}
-      - wget --quiet --output-document="{{.NODEMON_SCHEMA_PATH}}" {{.NODEMON_SCHEMA_URL}}
       - wget --quiet --output-document="{{.QUIKRUN_SCHEMA_PATH}}" {{.QUIKRUN_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" {{.SEMANTIC_RELEASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.STYLELINTRC_SCHEMA_PATH}}" {{.STYLELINTRC_SCHEMA_URL}}
       - |
         npx \
@@ -225,12 +225,12 @@ tasks:
             -r "{{.BASE_SCHEMA_PATH}}" \
             -r "{{.ESLINTRC_SCHEMA_PATH}}" \
             -r "{{.JSCPD_SCHEMA_PATH}}" \
+            -r "{{.NODEMON_SCHEMA_PATH}}" \
             -r "{{.NPM_BADGES_SCHEMA_PATH}}" \
             -r "{{.PARTIAL_ESLINT_PLUGINS_PATH}}" \
             -r "{{.PRETTIERRC_SCHEMA_PATH}}" \
-            -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
-            -r "{{.NODEMON_SCHEMA_PATH}}" \
             -r "{{.QUIKRUN_SCHEMA_PATH}}" \
+            -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
             -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
             -d "{{.INSTANCE_PATH}}"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -190,6 +190,10 @@ tasks:
       NODEMON_SCHEMA_URL: https://json.schemastore.org/nodemon.json
       NODEMON_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="nodemon-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/quikrun.json
+      QUIKRUN_SCHEMA_URL: https://json.schemastore.org/quikrun.json
+      QUIKRUN_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="quikrun-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/stylelintrc.json
       STYLELINTRC_SCHEMA_URL: https://json.schemastore.org/stylelintrc.json
       STYLELINTRC_SCHEMA_PATH:
@@ -207,6 +211,7 @@ tasks:
       - wget --quiet --output-document="{{.PRETTIERRC_SCHEMA_PATH}}" {{.PRETTIERRC_SCHEMA_URL}}
       - wget --quiet --output-document="{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" {{.SEMANTIC_RELEASE_SCHEMA_URL}}
       - wget --quiet --output-document="{{.NODEMON_SCHEMA_PATH}}" {{.NODEMON_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.QUIKRUN_SCHEMA_PATH}}" {{.QUIKRUN_SCHEMA_URL}}
       - wget --quiet --output-document="{{.STYLELINTRC_SCHEMA_PATH}}" {{.STYLELINTRC_SCHEMA_URL}}
       - |
         npx \
@@ -225,6 +230,7 @@ tasks:
             -r "{{.PRETTIERRC_SCHEMA_PATH}}" \
             -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
             -r "{{.NODEMON_SCHEMA_PATH}}" \
+            -r "{{.QUIKRUN_SCHEMA_PATH}}" \
             -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
             -d "{{.INSTANCE_PATH}}"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -186,6 +186,10 @@ tasks:
       SEMANTIC_RELEASE_SCHEMA_URL: https://json.schemastore.org/semantic-release.json
       SEMANTIC_RELEASE_SCHEMA_PATH:
         sh: task utility:mktemp-file TEMPLATE="semantic-release-schema-XXXXXXXXXX.json"
+      # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/nodemon.json
+      NODEMON_SCHEMA_URL: https://json.schemastore.org/nodemon.json
+      NODEMON_SCHEMA_PATH:
+        sh: task utility:mktemp-file TEMPLATE="nodemon-schema-XXXXXXXXXX.json"
       # Source: https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/stylelintrc.json
       STYLELINTRC_SCHEMA_URL: https://json.schemastore.org/stylelintrc.json
       STYLELINTRC_SCHEMA_PATH:
@@ -202,6 +206,7 @@ tasks:
       - wget --quiet --output-document="{{.PARTIAL_ESLINT_PLUGINS_PATH}}" {{.PARTIAL_ESLINT_PLUGINS_SCHEMA_URL}}
       - wget --quiet --output-document="{{.PRETTIERRC_SCHEMA_PATH}}" {{.PRETTIERRC_SCHEMA_URL}}
       - wget --quiet --output-document="{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" {{.SEMANTIC_RELEASE_SCHEMA_URL}}
+      - wget --quiet --output-document="{{.NODEMON_SCHEMA_PATH}}" {{.NODEMON_SCHEMA_URL}}
       - wget --quiet --output-document="{{.STYLELINTRC_SCHEMA_PATH}}" {{.STYLELINTRC_SCHEMA_URL}}
       - |
         npx \
@@ -219,6 +224,7 @@ tasks:
             -r "{{.PARTIAL_ESLINT_PLUGINS_PATH}}" \
             -r "{{.PRETTIERRC_SCHEMA_PATH}}" \
             -r "{{.SEMANTIC_RELEASE_SCHEMA_PATH}}" \
+            -r "{{.NODEMON_SCHEMA_PATH}}" \
             -r "{{.STYLELINTRC_SCHEMA_PATH}}" \
             -d "{{.INSTANCE_PATH}}"
 


### PR DESCRIPTION
## Summary
- In the `.github/workflows/check-npm-task.yml` workflow, the `npm:validate` task downloads a fixed list of referenced schemas to pass to `ajv validate`, but neither `nodemon.json` or `quikrun.json`were included
- This caused `ajv` to fail with `can't resolve reference <schema> from id https://json.schemastore.org/package.json`
