### PR TITLE
Fix workflow double-triggering on PRs for same-repo branches

### DIFF
--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -5,6 +5,8 @@ name: Check License
 on:
   create:
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/check-license.ya?ml"
       # See: https://github.com/licensee/licensee/blob/master/docs/what-we-look-at.md#detecting-the-license-file

--- a/.github/workflows/check-npm-dependencies-task.yml
+++ b/.github/workflows/check-npm-dependencies-task.yml
@@ -5,6 +5,8 @@ name: Check npm Dependencies
 on:
   create:
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/check-npm-dependencies-task.ya?ml"
       - ".licenses/**"

--- a/.github/workflows/check-npm-task.yml
+++ b/.github/workflows/check-npm-task.yml
@@ -5,6 +5,8 @@ name: Check npm
 on:
   create:
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/check-npm-task.ya?ml"
       - "**/.npmrc"

--- a/.github/workflows/check-packaging-ncc-typescript-npm.yml
+++ b/.github/workflows/check-packaging-ncc-typescript-npm.yml
@@ -2,6 +2,8 @@ name: Check Packaging
 
 on:
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/check-packaging-ncc-typescript-npm.yml"
       - ".npmrc"

--- a/.github/workflows/check-prettier-formatting-task.yml
+++ b/.github/workflows/check-prettier-formatting-task.yml
@@ -5,6 +5,8 @@ name: Check Prettier Formatting
 on:
   create:
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/check-prettier-formatting-task.ya?ml"
       - "Taskfile.ya?ml"

--- a/.github/workflows/check-toc-task.yml
+++ b/.github/workflows/check-toc-task.yml
@@ -5,6 +5,8 @@ name: Check ToC
 on:
   create:
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/check-toc-task.ya?ml"
       - ".npmrc"

--- a/.github/workflows/check-tsconfig-task.yml
+++ b/.github/workflows/check-tsconfig-task.yml
@@ -3,6 +3,8 @@ name: Check TypeScript Configuration
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/check-tsconfig-task.ya?ml"
       - "**/tsconfig*.json"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,6 +3,8 @@ name: Integration Tests
 on:
   pull_request:
   push:
+    branches:
+      - main
   schedule: # Scheduled trigger checks for breakage caused by changes to arduino-lint
     # run every Tuesday at 3 AM UTC
     - cron: "0 3 * * 2"

--- a/.github/workflows/spell-check-task.yml
+++ b/.github/workflows/spell-check-task.yml
@@ -5,6 +5,8 @@ name: Spell Check
 on:
   create:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.

--- a/.github/workflows/sync-labels-npm.yml
+++ b/.github/workflows/sync-labels-npm.yml
@@ -8,6 +8,8 @@ env:
 # See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/sync-labels-npm.ya?ml"
       - ".github/label-configuration-files/*.ya?ml"

--- a/.github/workflows/test-javascript-jest-task.yml
+++ b/.github/workflows/test-javascript-jest-task.yml
@@ -3,6 +3,8 @@ name: Test JavaScript
 
 on:
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/test-javascript-jest-task.ya?ml"
       - ".github/.?codecov.ya?ml"


### PR DESCRIPTION
- Add `branches: [main]` to the `push` trigger in all 11 workflows that also have a `pull_request` trigger
- Prevents each workflow from running twice when a commit is pushed to a PR branch (previously both `push` and `pull_request` events fired)
- The `push` trigger now only fires on merges to `main`; PR branch pushes are covered exclusively by `pull_request`
- This is more noticeable if you are either working on a fork, or are a maintainer/contributor and working on the same repo, as with forks, the upstream repo only sees the pull_request event, not the push event, hence only 18 CI tasks, rather than 36. 