### PR TITLE
Bump action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ inputs:
     required: false
     default: ${{ github.token }}
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"
 branding:
   icon: "check-square"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@actions/io": "^2.0.0",
         "@types/jest": "^30.0.0",
-        "@types/node": "^20.19.41",
+        "@types/node": "^24.0.0",
         "@types/semver": "^7.7.1",
         "@vercel/ncc": "^0.38.4",
         "ajv-cli": "^5.0.0",
@@ -30,7 +30,7 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "node": "20.x"
+        "node": "24.x"
       }
     },
     "node_modules/@actions/core": {
@@ -1424,13 +1424,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/semver": {
@@ -5949,9 +5949,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@actions/io": "^2.0.0",
     "@types/jest": "^30.0.0",
-    "@types/node": "^20.19.41",
+    "@types/node": "^24.0.0",
     "@types/semver": "^7.7.1",
     "@vercel/ncc": "^0.38.4",
     "ajv-cli": "^5.0.0",
@@ -38,6 +38,6 @@
     "typescript": "^6.0.3"
   },
   "engines": {
-    "node": "20.x"
+    "node": "24.x"
   }
 }


### PR DESCRIPTION
Resolves #627

- Update `action.yml` runtime from `node20` to `node24`
- Update `engines.node` from `20.x` to `24.x` in `package.json`
- Bump `@types/node` from `^20.19.41` to `^24.0.0` (presently resolves to `24.12.4`)
- Update `package-lock.json` accordingly

Built and tested locally under Node.js 24.15.0 (current LTS) via fnm.

Needed due to the NodeJS 20 deprecation by GitHub. c.f. https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

I see you are also maintaining a copy of arduino/setup-task, rather than use the official action at https://github.com/go-task/setup-task ... I can look into changing that over if you wish. 

