### PR TITLE
Update major version ref in readme snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: arduino/arduino-lint-action@v2
+      - uses: arduino/arduino-lint-action@v3
 ```
 
 A more complex workflow which uses [inputs](#inputs) to configure the action for Library Manager ["update" mode](#library-manager) and strict compliance:
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: arduino/arduino-lint-action@v2
+      - uses: arduino/arduino-lint-action@v3
         with:
           library-manager: update
           compliance: strict


### PR DESCRIPTION
Following the 3.0.0 release of the action, the current major version ref is now v3. The action usage example snippets in the project readme are hereby updated to demonstrate the use of that ref.